### PR TITLE
Bump version to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.3.0] - 2023-11-08
+
  - [#231](https://github.com/sharesight/find-github-pull-request/pull/231) - Bump tough-cookie from 4.0.0 to 4.1.3
  - [#233](https://github.com/sharesight/find-github-pull-request/pull/233) - Bump semver from 6.3.0 to 6.3.1
  - [#235](https://github.com/sharesight/find-github-pull-request/pull/235) - Bump word-wrap from 1.2.3 to 1.2.4
  - [#243](https://github.com/sharesight/find-github-pull-request/pull/243) - Bump @types/node from 17.0.33 to 20.5.1
  - [#244](https://github.com/sharesight/find-github-pull-request/pull/244) - Bump @babel/traverse from 7.15.4 to 7.23.2
+ - [#245](https://github.com/sharesight/find-github-pull-request/pull/245) - Update dependencies
  - [#246](https://github.com/sharesight/find-github-pull-request/pull/246) - Bump @types/node from 20.5.1 to 20.8.10
  - [#245](https://github.com/sharesight/find-github-pull-request/pull/247) - Bump @actions/core from 1.10.0 to 1.10.1
  - [#249](https://github.com/sharesight/find-github-pull-request/pull/249) - Bump @vercel/ncc from 0.36.1 to 0.38.1

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
 
       - name: Find Pull Request
         id: find-pr
-        uses: sharesight/find-github-pull-request@1.2.0
+        uses: sharesight/find-github-pull-request@1.3.0
         with:
           # These are all default values.
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/dist/index.js
+++ b/dist/index.js
@@ -558,7 +558,7 @@ class OidcClient {
                 .catch(error => {
                 throw new Error(`Failed to get ID Token. \n 
         Error Code : ${error.statusCode}\n 
-        Error Message: ${error.result.message}`);
+        Error Message: ${error.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
             if (!id_token) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "find-github-pull-request",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Find a Github Pull Request in a Github Action",
   "main": "dist/index.js",
   "author": {


### PR DESCRIPTION
This release focuses on bumping several dependencies:

 - [#231](https://github.com/sharesight/find-github-pull-request/pull/231) - Bump tough-cookie from 4.0.0 to 4.1.3
 - [#233](https://github.com/sharesight/find-github-pull-request/pull/233) - Bump semver from 6.3.0 to 6.3.1
 - [#235](https://github.com/sharesight/find-github-pull-request/pull/235) - Bump word-wrap from 1.2.3 to 1.2.4
 - [#243](https://github.com/sharesight/find-github-pull-request/pull/243) - Bump @types/node from 17.0.33 to 20.5.1
 - [#244](https://github.com/sharesight/find-github-pull-request/pull/244) - Bump @babel/traverse from 7.15.4 to 7.23.2
 - [#245](https://github.com/sharesight/find-github-pull-request/pull/245) - Update dependencies
 - [#246](https://github.com/sharesight/find-github-pull-request/pull/246) - Bump @types/node from 20.5.1 to 20.8.10
 - [#245](https://github.com/sharesight/find-github-pull-request/pull/247) - Bump @actions/core from 1.10.0 to 1.10.1
 - [#249](https://github.com/sharesight/find-github-pull-request/pull/249) - Bump @vercel/ncc from 0.36.1 to 0.38.1